### PR TITLE
Manually select memory types to avoid padding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ git config core.hooksPath .githooks
 - `Surface<T>` holds `Arc<Instance>` and `Arc<T>` for lifetime safety.
 - Device selection uses a priority-based fold over physical devices.
 
+## Verification
+
+Always use `cargo clippy` (not just `cargo check`) to verify code after
+writing it. CI runs clippy with `-D warnings` per package; rust-analyzer
+surfaces clippy diagnostics in the editor but Claude Code cannot observe
+them, so running clippy in the shell is the only reliable check.
+
 ## Feature Unification Gotcha
 Workspace feature unification can hide missing features. Always verify
 individual crates with `cargo check -p <crate>` rather than relying on

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ If `shader.debug.spv` is missing, the app falls back to `shader.spv`.
 
 ## Useful checks
 
+The project targets zero clippy warnings; CI enforces `-D warnings`
+per package.
+
 ```sh
 cargo check -p rgpu-vk
 cargo check -p samp-app

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Before this patch, we let gpu-allocator pick our memory type. However, to deal with non-coherent memory types, we had to pad out our allocations to a multiple of the noncoherent atom size of the device because we couldn't promise that it wouldn't end up in non-coherent memory. Now we can know whether or not we get a non-coherent memory type and only pad if necessary.