### PR TITLE
Improve CLI logging controls and fix Vulkan debug target name

### DIFF
--- a/rgpu-vk/src/instance.rs
+++ b/rgpu-vk/src/instance.rs
@@ -165,7 +165,7 @@ unsafe extern "system" fn vulkan_debug_callback(
     match message_severity {
         vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => {
             tracing::trace!(
-                target: "rvk-debug-messenger",
+                target: "rgpu_vk::instance::debug_utils",
                 "[{}] {}",
                 type_str,
                 message
@@ -173,7 +173,7 @@ unsafe extern "system" fn vulkan_debug_callback(
         }
         vk::DebugUtilsMessageSeverityFlagsEXT::INFO => {
             tracing::info!(
-                target: "rvk-debug-messenger",
+                target: "rgpu_vk::instance::debug_utils",
                 "[{}] {}",
                 type_str,
                 message
@@ -181,7 +181,7 @@ unsafe extern "system" fn vulkan_debug_callback(
         }
         vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => {
             tracing::warn!(
-                target: "rvk-debug-messenger",
+                target: "rgpu_vk::instance::debug_utils",
                 "[{}] {}",
                 type_str,
                 message
@@ -189,7 +189,7 @@ unsafe extern "system" fn vulkan_debug_callback(
         }
         vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => {
             tracing::error!(
-                target: "rvk-debug-messenger",
+                target: "rgpu_vk::instance::debug_utils",
                 "[{}] {}",
                 type_str,
                 message
@@ -197,7 +197,7 @@ unsafe extern "system" fn vulkan_debug_callback(
         }
         _ => {
             tracing::debug!(
-                target: "rvk-debug-messenger",
+                target: "rgpu_vk::instance::debug_utils",
                 "[{}] {}",
                 type_str,
                 message


### PR DESCRIPTION
## Summary

- Add `--rgpu-log-level` flag to set `rgpu_vk` tracing verbosity independently from the global `--tracing-log-level`, making it easy to enable detailed Vulkan wrapper traces without affecting the rest of the app.
- Rename the Vulkan debug-utils tracing target from `"rvk-debug-messenger"` to `"rgpu_vk::instance::debug_utils"` so `--graphics-debug-level` can be wired to that specific target rather than the entire `rgpu_vk` crate.
- Remove `-t`/`-s` short aliases from `--tracing-log-level` and `--graphics-debug-level` to avoid single-letter collisions as the arg set grows.

## Test plan

- [ ] `cargo clippy -p rgpu-vk` — no warnings
- [ ] `cargo clippy -p samp-app` — no warnings
- [ ] `--rgpu-log-level trace` emits `rgpu_vk` logs without affecting other targets
- [ ] `--graphics-debug-level trace` emits Vulkan callback messages without enabling all `rgpu_vk` logs

> Generated with Claude's assistance.