### PR TITLE
Add asset system outline and Git LFS support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+command -v git-lfs >/dev/null 2>&1 || {
+    echo >&2 "git-lfs not found; install it or remove the LFS \
+configuration from this repo."
+    exit 2
+}
+
+git lfs post-checkout "$@"

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+command -v git-lfs >/dev/null 2>&1 || {
+    echo >&2 "git-lfs not found; install it or remove the LFS \
+configuration from this repo."
+    exit 2
+}
+
+git lfs post-commit "$@"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+command -v git-lfs >/dev/null 2>&1 || {
+    echo >&2 "git-lfs not found; install it or remove the LFS \
+configuration from this repo."
+    exit 2
+}
+
+git lfs post-merge "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,26 @@
 #!/bin/bash
 set -e
 
+command -v git-lfs >/dev/null 2>&1 || {
+    echo >&2 "git-lfs not found; install it or remove the LFS \
+configuration from this repo."
+    exit 2
+}
+
+# Buffer stdin so both consumers can read it.
+stdin=$(cat)
+
+# Upload LFS objects before the push proceeds.
+echo "$stdin" | git lfs pre-push "$@"
+
 protected_branch="main"
 
-while read local_ref local_sha remote_ref remote_sha; do
+while read -r local_ref local_sha remote_ref remote_sha; do
     if [[ "$remote_ref" == "refs/heads/$protected_branch" ]]; then
         echo "Direct push to '$protected_branch' is not allowed."
         echo "Open a PR or use --no-verify to bypass."
         exit 1
     fi
-done
+done <<< "$stdin"
 
 exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "asset-pipeline"
+version = "0.1.0"
+dependencies = [
+ "path-slash",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1216,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1351,12 +1366,14 @@ dependencies = [
 name = "samp-app"
 version = "0.1.0"
 dependencies = [
+ "asset-pipeline",
  "bytemuck",
  "clap",
  "directories",
  "eyre",
  "rgpu-vk",
  "supports-color",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "vek",
@@ -1416,6 +1433,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1586,6 +1612,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,12 +1643,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -1614,6 +1675,12 @@ checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2338,6 +2405,10 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 [[package]]
 name = "xtask"
 version = "0.1.0"
+dependencies = [
+ "asset-pipeline",
+ "toml",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
-members = ["rgpu-vk", "samp-app", "xtask"]
+members = ["asset-pipeline", "rgpu-vk", "samp-app", "xtask"]
 default-members = ["rgpu-vk", "samp-app"]
 resolver = "3"

--- a/asset-pipeline/Cargo.toml
+++ b/asset-pipeline/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "asset-pipeline"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+path-slash = "0.2"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"

--- a/asset-pipeline/src/lib.rs
+++ b/asset-pipeline/src/lib.rs
@@ -1,0 +1,99 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+// ---- Workspace manifest (assets/manifest.toml) ----------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manifest {
+    pub asset: Vec<ManifestEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    pub name: String,
+    #[serde(with = "path_serde")]
+    pub file: PathBuf,
+    #[serde(rename = "type")]
+    pub asset_type: String,
+    pub source: Option<String>,
+    pub author: Option<String>,
+    pub license: Option<String>,
+    pub notes: Option<String>,
+}
+
+// ---- App asset list (samp-app/src/assets.toml) ----------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppAssets {
+    pub asset: Vec<AppAssetRef>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppAssetRef {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub asset_type: String,
+}
+
+// ---- Generated map (out/.../assets/asset_map.toml) ------------------
+
+/// Maps logical asset names to filenames in the output assets directory.
+/// Serialized by xtask during the build; deserialized by apps at runtime.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AssetMap {
+    #[serde(with = "path_map_serde")]
+    pub map: BTreeMap<String, PathBuf>,
+}
+
+// ---- Serde helpers: forward-slash paths -----------------------------
+
+mod path_serde {
+    use std::path::PathBuf;
+
+    use path_slash::PathBufExt as _;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        path: &PathBuf,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        path.to_slash_lossy().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<PathBuf, D::Error> {
+        Ok(PathBuf::from_slash(String::deserialize(d)?))
+    }
+}
+
+mod path_map_serde {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use path_slash::PathBufExt as _;
+    use serde::{
+        Deserialize, Deserializer, Serializer, ser::SerializeMap,
+    };
+
+    pub fn serialize<S: Serializer>(
+        map: &BTreeMap<String, PathBuf>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut ser = s.serialize_map(Some(map.len()))?;
+        for (k, v) in map {
+            ser.serialize_entry(k, &*v.to_slash_lossy())?;
+        }
+        ser.end()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<BTreeMap<String, PathBuf>, D::Error> {
+        BTreeMap::<String, String>::deserialize(d).map(|m| {
+            m.into_iter()
+                .map(|(k, v)| (k, PathBuf::from_slash(v)))
+                .collect()
+        })
+    }
+}

--- a/assets/manifest.toml
+++ b/assets/manifest.toml
@@ -1,0 +1,12 @@
+[[asset]]
+name = "statue-tex"
+file = "statue-tex.png"
+source = "https://pixabay.com/photos/statue-sculpture-figure-1275469/"
+author = "Undocumented on Pixabay"
+license = "Pixabay Content License https://pixabay.com/service/terms/"
+type = "image"
+notes = """
+Modified by vulkan-tutorial \
+(https://docs.vulkan.org/tutorial/latest/06_Texture_mapping/00_Images.html) \
+to be 512x512. Incorrectly marked CC0 on the tutorial\
+"""

--- a/assets/statue-tex.png
+++ b/assets/statue-tex.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a83b170636bad86a44c3f6c28f62f5530378ec28d1f728eb9696d8752cd92026
+size 370640

--- a/samp-app/Cargo.toml
+++ b/samp-app/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
+asset-pipeline = { path = "../asset-pipeline" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
 clap = { version = "4.5", features = ["derive"] }
 directories = "6.0.0"
@@ -12,6 +13,7 @@ eyre = "0.6.12"
 rgpu-vk = { version = "0.1.0", path = "../rgpu-vk" }
 tracing = "0.1.44"
 supports-color = "3"
+toml = "0.8"
 tracing-subscriber = "0.3.22"
 vek = { version = "0.17.2", features = ["bytemuck"] }
 winit = "0.30.12"

--- a/samp-app/src/assets.toml
+++ b/samp-app/src/assets.toml
@@ -1,0 +1,3 @@
+[[asset]]
+name = "statue-tex"
+type = "image"

--- a/samp-app/src/main.rs
+++ b/samp-app/src/main.rs
@@ -10,6 +10,7 @@ use std::{
     time::Instant,
 };
 
+use asset_pipeline::AssetMap;
 use bytemuck::{Pod, Zeroable};
 use clap::Parser;
 use rgpu_vk::{
@@ -459,6 +460,7 @@ struct RunningState {
     /// Wall-clock time at which the app entered the Running state;
     /// used to drive the rotation animation.
     start_time: Instant,
+    asset_map: AssetMap,
 }
 
 impl std::fmt::Debug for RunningState {
@@ -501,6 +503,7 @@ struct SuspendedState {
     ubo_buffers: Vec<HostVisibleBuffer>,
     descriptor_sets: Vec<DescriptorSet>,
     start_time: Instant,
+    asset_map: AssetMap,
 }
 #[derive(Debug)]
 struct ExitingState {}
@@ -579,6 +582,7 @@ impl ApplicationHandler for AppRunner {
                 ubo_buffers,
                 descriptor_sets,
                 start_time,
+                asset_map,
             } = running_state;
 
             if let Err(e) = device.wait_idle() {
@@ -615,6 +619,7 @@ impl ApplicationHandler for AppRunner {
                 ubo_buffers,
                 descriptor_sets,
                 start_time,
+                asset_map,
             });
         }
     }
@@ -1341,6 +1346,15 @@ impl AppRunner {
             unsafe { set.write_uniform_buffer(&device, 0, buf, ubo_size) };
         }
 
+        let asset_map_path =
+            state.self_dir.join("assets").join("asset_map.toml");
+        let asset_map: AssetMap = toml::from_str(
+            &std::fs::read_to_string(&asset_map_path).map_err(|e| {
+                eyre::eyre!("Failed to read {}: {e}", asset_map_path.display())
+            })?,
+        )?;
+        tracing::debug!(asset_map = ?asset_map.map, "Loaded asset map");
+
         // SAFETY: guard will call wait_idle in Drop. Must not be forgotten.
         let idle_guard =
             unsafe { RunningStateTransitionGuard::new(Arc::clone(&device)) };
@@ -1366,6 +1380,7 @@ impl AppRunner {
             ubo_buffers,
             descriptor_sets,
             start_time: Instant::now(),
+            asset_map,
         })
     }
 
@@ -1477,6 +1492,7 @@ impl AppRunner {
             ubo_buffers: state.ubo_buffers,
             descriptor_sets: state.descriptor_sets,
             start_time: state.start_time,
+            asset_map: state.asset_map,
         })
     }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,3 +3,7 @@ name = "xtask"
 version = "0.1.0"
 edition = "2024"
 publish = false
+
+[dependencies]
+asset-pipeline = { path = "../asset-pipeline" }
+toml = "0.8"

--- a/xtask/src/assets.rs
+++ b/xtask/src/assets.rs
@@ -1,0 +1,85 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::Path,
+};
+
+use asset_pipeline::{AppAssets, AssetMap, Manifest, ManifestEntry};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub(crate) fn copy_assets(
+    manifest_path: &Path,
+    app_assets_path: &Path,
+    assets_src_dir: &Path,
+    dst_dir: &Path,
+) -> Result<()> {
+    let manifest: Manifest =
+        toml::from_str(&fs::read_to_string(manifest_path)?)?;
+    let app_assets: AppAssets =
+        toml::from_str(&fs::read_to_string(app_assets_path)?)?;
+
+    let index: HashMap<&str, &ManifestEntry> =
+        manifest.asset.iter().map(|e| (e.name.as_str(), e)).collect();
+
+    fs::create_dir_all(dst_dir)?;
+
+    let mut map = BTreeMap::new();
+    let mut copied = 0u32;
+    let mut skipped = 0u32;
+
+    for req in &app_assets.asset {
+        let entry = index.get(req.name.as_str()).ok_or_else(|| {
+            format!(
+                "asset `{}` not found in manifest",
+                req.name
+            )
+        })?;
+
+        if entry.asset_type != req.asset_type {
+            return Err(format!(
+                "asset `{}`: manifest type `{}` != app type `{}`",
+                req.name, entry.asset_type, req.asset_type,
+            )
+            .into());
+        }
+
+        let src = assets_src_dir.join(&entry.file);
+        let dst = dst_dir.join(&entry.file);
+
+        if is_up_to_date(&src, &dst) {
+            skipped += 1;
+        } else {
+            fs::copy(&src, &dst)?;
+            println!("Copied {}", entry.file.display());
+            copied += 1;
+        }
+
+        map.insert(req.name.clone(), entry.file.clone());
+    }
+
+    let asset_map = AssetMap { map };
+    fs::write(
+        dst_dir.join("asset_map.toml"),
+        toml::to_string(&asset_map)?,
+    )?;
+
+    println!("Assets: {copied} copied, {skipped} up-to-date");
+    Ok(())
+}
+
+fn is_up_to_date(src: &Path, dst: &Path) -> bool {
+    let Ok(src_meta) = src.metadata() else {
+        return false;
+    };
+    let Ok(dst_meta) = dst.metadata() else {
+        return false;
+    };
+    let Ok(src_mtime) = src_meta.modified() else {
+        return false;
+    };
+    let Ok(dst_mtime) = dst_meta.modified() else {
+        return false;
+    };
+    src_mtime <= dst_mtime
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+mod assets;
+
 use std::{
     env,
     ffi::OsStr,
@@ -65,8 +67,18 @@ fn all_tasks() -> Vec<Task> {
             run: copy_exe,
         },
         Task {
+            name: "copy-assets",
+            deps: &[],
+            run: copy_assets,
+        },
+        Task {
             name: "build",
-            deps: &["cargo-build", "compile-shaders", "copy-exe"],
+            deps: &[
+                "cargo-build",
+                "compile-shaders",
+                "copy-exe",
+                "copy-assets",
+            ],
             run: noop,
         },
     ]
@@ -283,4 +295,18 @@ fn copy_exe() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn copy_assets() -> Result<()> {
+    let root = workspace_root();
+    assets::copy_assets(
+        &root.join("assets").join("manifest.toml"),
+        &root.join("samp-app").join("src").join("assets.toml"),
+        &root.join("assets"),
+        &root
+            .join("out")
+            .join("samp-app")
+            .join("debug")
+            .join("assets"),
+    )
 }


### PR DESCRIPTION
## Summary

- Add new `asset-pipeline` crate: defines `AssetMap` (deserialised from a TOML manifest) and a `copy_assets` helper invoked at build time to collect processed assets into the output directory.
- Add `assets/` directory with `manifest.toml` and the first texture (`statue-tex.png`). PNGs are now LFS-tracked via a new `.gitattributes` rule.
- Wire a `copy-assets` xtask task into the top-level `build` task graph.
- Load and store the `AssetMap` in `samp-app` at startup; the map is carried through `RunningState`/`SuspendedState` round-trips.
- Add LFS lifecycle hooks (`post-checkout`, `post-commit`, `post-merge`) and extend `pre-push` to run `git lfs pre-push`; also fix a `read -r` quoting issue in the existing branch-protection loop.

## Test plan

- [ ] `cargo clippy -p asset-pipeline` — no warnings
- [ ] `cargo clippy -p samp-app` — no warnings
- [ ] `cargo xtask build` runs `copy-assets` without error
- [ ] After cloning fresh, `git lfs pull` retrieves `statue-tex.png`
- [ ] App starts and logs "Loaded asset map" at debug level

> Generated with Claude's assistance.