### PR TITLE
Fix SAFETY comment accuracy and formatting

### DIFF
--- a/rgpu-vk/src/buffer.rs
+++ b/rgpu-vk/src/buffer.rs
@@ -379,6 +379,8 @@ impl DeviceLocalBuffer {
     ///   execution of the submitted copy has completed.
     /// - If `fence` is `Some`, the caller must ensure it is unsignaled and
     ///   later wait/reset it before reusing resources referenced by the copy.
+    /// - `src` must be created with vk::BufferUsageFlags::TRANSFER_SRC and
+    ///   `self` must be created with vk::BufferusageFlags::TRANSFER_DST
     pub unsafe fn upload_from_host_visible(
         &mut self,
         command_buffer: &mut impl CommandBufferHandle,
@@ -393,7 +395,8 @@ impl DeviceLocalBuffer {
             });
         }
 
-        // SAFETY: forwards to region helper with full-buffer offsets and size.
+        // SAFETY: This functions preconditions carry through. Offset of 0 is
+        // definitionally in bounds
         unsafe {
             self.upload_from_host_visible_region(
                 command_buffer,
@@ -416,6 +419,8 @@ impl DeviceLocalBuffer {
     ///   execution of the submitted copy has completed.
     /// - If `fence` is `Some`, the caller must ensure it is unsignaled and
     ///   later wait/reset it before reusing resources referenced by the copy.
+    /// - `src` must be created with vk::BufferUsageFlags::TRANSFER_SRC and
+    ///   `self` must be created with vk::BufferusageFlags::TRANSFER_DST
     pub unsafe fn upload_from_host_visible_region(
         &mut self,
         command_buffer: &mut impl CommandBufferHandle,

--- a/samp-app/src/main.rs
+++ b/samp-app/src/main.rs
@@ -782,7 +782,6 @@ impl AppRunner {
         // is complete.
         unsafe { frame_objs.release_retained() };
 
-        // SAFETY: is_none() is checked at the top of this function.
         let sc = state
             .swapchain
             .as_ref()
@@ -914,8 +913,7 @@ impl AppRunner {
                 &[&state.descriptor_sets[frame_idx]],
             )
         };
-        // SAFETY: inside render pass recording; buffer is valid and bound to
-        // host-visible memory for the app lifetime.
+        // SAFETY: inside render pass recording; buffer is valid
         unsafe { frame_cmd.bind_vertex_buffer(0, &*state.vertex_buffer, 0) };
 
         let viewport = vk::Viewport {


### PR DESCRIPTION
Closes #13.

## Summary

- Normalise all `//SAFETY:` (no space) to `// SAFETY:` throughout `instance.rs`
- Fill in the empty `create_raw_surface` SAFETY comment with the actual liveness and lifetime rationale
- Replace vague `"Pretty much always fine"` and `"Valid CI"` comments with accurate precondition descriptions
- Remove the incorrect `// SAFETY:` prefix from the safe `.expect()` call in `draw_frame`
- Drop the wrong "host-visible memory" detail from the `bind_vertex_buffer` safety comment
- Improve the `upload_from_host_visible` inline comment to explain *why* the delegation is safe, not just *what* it does
- Add `TRANSFER_SRC` / `TRANSFER_DST` usage-flag requirements to the `# Safety` docs of both `upload_from_host_visible` and `upload_from_host_visible_region`

*Generated with Claude's assistance.*